### PR TITLE
replace deprecation package

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
-const Vinyl = require('vinyl')
-const PluginError = Vinyl.PluginError
+const PluginError = require('plugin-error')
 const through = require('through2')
 const pluginName = 'gulp-webp-html-nosvg'
 

--- a/package.json
+++ b/package.json
@@ -4,10 +4,9 @@
 	"description": "Replaces the <img> tag with <picture> <source> <img> in HTML files. No SVG, GIF format and data- support",
 	"main": "index.js",
 	"dependencies": {
-		"gulp-util": "^3.0.8",
+		"plugin-error": "^2.0.1",
 		"through2": "^3.0.1"
 	},
-	"devDependencies": {},
 	"scripts": {
 		"test": "echo \"Error: no test specified\" && exit 1"
 	},


### PR DESCRIPTION
gulp-util is deprecated - replace it, following the guidelines at https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5